### PR TITLE
Implement NLog for Centralized Logging

### DIFF
--- a/LegacyOrderService.csproj
+++ b/LegacyOrderService.csproj
@@ -21,6 +21,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageReference Include="NLog" Version="6.0.3" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,4 +1,9 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=order.db"
   }

--- a/nlog.config
+++ b/nlog.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      throwConfigExceptions="true"
+      internalLogLevel="Warn"
+      internalLogFile="internal-nlog.txt">
+
+	<!-- Targets (where to write logs) -->
+	<targets>
+		<!-- File log -->
+		<target xsi:type="File" name="fileLog"
+				fileName="logs/logfile-${shortdate}.log"
+				layout="${longdate} | ${level:uppercase=true} | ${logger} | ${message} ${exception}" />
+	</targets>
+
+	<!-- Rules (what goes where) -->
+	<rules>
+		<logger name="*" minlevel="Info" writeTo="fileLog" />
+	</rules>
+</nlog>


### PR DESCRIPTION
Added NLog dependency and configuration (`nlog.config`).
Configured HostBuilder to use NLog for all logging.
Removed default logging providers and set minimum logging level.
Enabled logging for Entity Framework Core commands.
Updated `appsettings.json` to support log configuration.